### PR TITLE
[BUG] Password reset mails dont go to email, they go to "username" instead

### DIFF
--- a/2-advanced/classes/Login.php
+++ b/2-advanced/classes/Login.php
@@ -532,7 +532,7 @@ class Login {
      */
     public function sendPasswordResetMail() {
         
-        $to      = $this->user_name;
+        $to      = $this->user_email;
         $subject = EMAIL_PASSWORDRESET_SUBJECT;
         
         $link    = EMAIL_PASSWORDRESET_URL.'?user_name='.urlencode($this->user_name).'&verification_code='.urlencode($this->user_password_reset_hash);


### PR DESCRIPTION
Password reset emails are going to the username for the email address, not the actual email address registered with the account. C'mon!
