### PR TITLE
Test for PHP 5.5 and require password_compatibility_library.php

### DIFF
--- a/1-minimal/index.php
+++ b/1-minimal/index.php
@@ -24,11 +24,11 @@
 // checking for minimum PHP version
 if (version_compare(PHP_VERSION, '5.3.7', '<') ) {    
   exit("Sorry, Simple PHP Login does not run on a PHP version smaller than 5.3.7 !");  
+} else if (version_compare(PHP_VERSION, '5.5.0', '<') ) {
+  // if you are using PHP 5.3 or PHP 5.4 you have to include the password_api_compatibility_library.php
+  // (this library adds the PHP 5.5 password hashing functions to older versions of PHP)
+  require_once("libraries/password_compatibility_library.php");
 }
-
-// if you are using PHP 5.3 or PHP 5.4 you have to include the password_api_compatibility_library.php
-// (this library adds the PHP 5.5 password hashing functions to older versions of PHP)
-require_once("libraries/password_compatibility_library.php");
 
 // include the configs / constants for the database connection
 require_once("config/db.php");


### PR DESCRIPTION
A simple test to auto require the password compat lib only if version less than PHP 5.5, otherwise ignore that lib. Perhaps I should have added this to the development branch, sorry.
