### PR TITLE
Remove use of Gravatar's force default parameter

### DIFF
--- a/2-advanced/classes/Login.php
+++ b/2-advanced/classes/Login.php
@@ -726,7 +726,7 @@ class Login
      * Gravatar is the #1 (free) provider for email address based global avatar hosting.
      * The URL (or image) returns always a .jpg file !
      * For deeper info on the different parameter possibilities:
-     * @see http://de.gravatar.com/site/implement/images/
+     * @see http://gravatar.com/site/implement/images/
      *
      * @param string $email The email address
      * @param string $s Size in pixels, defaults to 50px [ 1 - 2048 ]
@@ -739,9 +739,9 @@ class Login
     {
         $url = 'http://www.gravatar.com/avatar/';
         $url .= md5(strtolower(trim($email)));
-        $url .= "?s=$s&d=$d&r=$r&f=y";
+        $url .= "?s=$s&d=$d&r=$r";
 
-        // the image url (on gravatarr servers), will return in something like
+        // the image url (on gravatar servers), will return in something like
         // http://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=80&d=mm&r=g
         // note: the url does NOT have something like .jpg
         $this->user_gravatar_image_url = $url;

--- a/4-full-mvc-framework/models/login_model.php
+++ b/4-full-mvc-framework/models/login_model.php
@@ -677,7 +677,7 @@ class Login_Model extends Model
         $url .= md5( strtolower( trim( $email ) ) );
         $url .= "?s=$s&d=$d&r=$r";
         
-        // the image url (on gravatarr servers), will return in something like
+        // the image url (on gravatar servers), will return in something like
         // http://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=80&d=mm&r=g
         // note: the url does NOT have something like .jpg
         Session::set('user_gravatar_image_url', $url);

--- a/4-full-mvc-framework/models/overview_model.php
+++ b/4-full-mvc-framework/models/overview_model.php
@@ -84,7 +84,7 @@ class Overview_Model extends Model {
         $gravatar_image_link .= md5( strtolower( trim( $email ) ) );
         $gravatar_image_link .= "?s=$s&d=$d&r=$r";
         
-        // the image url (on gravatarr servers), will return in something like
+        // the image url (on gravatar servers), will return in something like
         // http://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=80&d=mm&r=g
         // note: the url does NOT have something like .jpg
         return $gravatar_image_link;


### PR DESCRIPTION
Possible oversight in the inclusion of Gravatar's force default parameter? Miscellaneous comment fixes included as well.

Any thoughts on providing an option to use secure Gravatar requests or even defaulting to it?

```
http://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=80&d=mm&r=g
```

to

```
https://secure.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=80&d=mm&r=g
```
