### PR TITLE
Cookie login flag

### DIFF
--- a/application/models/login_model.php
+++ b/application/models/login_model.php
@@ -195,6 +195,8 @@ class LoginModel
             Session::set('user_account_type', $result->user_account_type);
             Session::set('user_provider_type', 'DEFAULT');
             Session::set('user_avatar_file', $this->getUserAvatarFilePath());
+            //Cookie login flag
+            Session::set('loged_in_with_cookie',true);
             // call the setGravatarImageUrl() method which writes gravatar urls into the session
             $this->setGravatarImageUrl($result->user_email, AVATAR_SIZE);
 


### PR DESCRIPTION
Whenever a user logs in with cookie data we should consider the scenario where someone else accesed his computer and found him loged in. In that case we request a re-enter of the password when performing sesitive actions.
To achive this I added a sesion flag $_SESSION['logged_in_with_cookie']=1; that should be checked whenever that kind of sensitive requests are made.
