### PR TITLE
LoginModel incorrect defined() calls

### DIFF
--- a/application/models/login_model.php
+++ b/application/models/login_model.php
@@ -550,7 +550,7 @@ class LoginModel
             // enable SMTP authentication
             $mail->SMTPAuth = EMAIL_SMTP_AUTH;
             // enable encryption, usually SSL/TLS
-            if (defined(EMAIL_SMTP_ENCRYPTION)) {
+            if (defined('EMAIL_SMTP_ENCRYPTION')) {
                 $mail->SMTPSecure = EMAIL_SMTP_ENCRYPTION;
             }
             // set SMTP provider's credentials
@@ -905,7 +905,7 @@ class LoginModel
             // Enable SMTP authentication
             $mail->SMTPAuth = EMAIL_SMTP_AUTH;
             // Enable encryption, usually SSL/TLS
-            if (defined(EMAIL_SMTP_ENCRYPTION)) {
+            if (defined('EMAIL_SMTP_ENCRYPTION')) {
                 $mail->SMTPSecure = EMAIL_SMTP_ENCRYPTION;
             }
             // Specify host server


### PR DESCRIPTION
defined() called with constant not string of constant's name in both LoginModel::sendVerificationEmail() and LoginModel::sendPasswordResetMail()

produced false, false in conditional statements.
