### PR TITLE
Captcha-Reload Hotfix

### DIFF
--- a/application/views/login/register.php
+++ b/application/views/login/register.php
@@ -39,7 +39,7 @@
             <!-- to avoid weird with-slash-without-slash issues: simply always use the URL constant here -->
             <img id="captcha" src="<?php echo URL; ?>login/showCaptcha" />
             <span style="display: block; font-size: 11px; color: #999; margin-bottom: 10px">
-                <a href="#" onclick="document.getElementById('captcha').src = '<?php echo URL; ?>login/showCaptcha' + Math.random(); return false">[ Reload Captcha ]</a>
+                <a href="#" onclick="document.getElementById('captcha').src = '<?php echo URL; ?>login/showCaptcha?' + Math.random(); return false">[ Reload Captcha ]</a>
             </span>
             <label>
                 Please enter these characters


### PR DESCRIPTION
Hey,
You've just merged this into the script and I gave it a try, but the reload function is not working under Firefox, because of the missing "?" behind " login/showCaptcha" in the link.

The links now look something like this: "login/showCaptcha0.12456148" instead of "login/showCaptcha?0.12456148" if you want to reload the captcha.

I hope you understand what I'm trying to explain.
