### PR TITLE
install php cli

### DIFF
--- a/_one-click-installation/bootstrap.sh
+++ b/_one-click-installation/bootstrap.sh
@@ -60,6 +60,9 @@ sudo apt-get -y install git
 # git clone HUGE
 sudo git clone https://github.com/panique/huge "/var/www/html/${PROJECTFOLDER}"
 
+# install php cli
+sudo apt-get install php5-cli
+
 # install Composer
 curl -s https://getcomposer.org/installer | php
 mv composer.phar /usr/local/bin/composer


### PR DESCRIPTION
some fresh install don't install the php cli library in default... and you will get error message... 
like: #The program 'php' is currently not installed. You can install it by typing...
so, make sure the php5-cli are installed to yours system before try to use...