### PR TITLE
install php cli

### DIFF
--- a/_one-click-installation/bootstrap.sh
+++ b/_one-click-installation/bootstrap.sh
@@ -12,6 +12,7 @@ sudo apt-get -y upgrade
 
 sudo apt-get install -y apache2
 sudo apt-get install -y php5
+sudo apt-get install -y php5-cli
 
 sudo debconf-set-selections <<< "mysql-server mysql-server/root_password password $PASSWORD"
 sudo debconf-set-selections <<< "mysql-server mysql-server/root_password_again password $PASSWORD"


### PR DESCRIPTION
some fresh install don't install the php cli library in default... and you will get error message... 
like: #The program 'php' is currently not installed. You can install it by typing...
so, make sure the php5-cli are installed to yours system before try to use...