### PR TITLE
simplifying Session::get($key)

### DIFF
--- a/application/core/Session.php
+++ b/application/core/Session.php
@@ -39,8 +39,9 @@ class Session
     public static function get($key)
     {
         if (isset($_SESSION[$key])) {
+            $value = $_SESSION[$key];
         	// filter the value for XSS vulnerabilities
-        	return Filter::XSSFilter($_SESSION[$key]);
+        	return Filter::XSSFilter($value);
         }
     }
 

--- a/application/core/Session.php
+++ b/application/core/Session.php
@@ -39,15 +39,9 @@ class Session
     public static function get($key)
     {
         if (isset($_SESSION[$key])) {
-			if (is_string($_SESSION[$key])) {
-                // filter the value for XSS vulnerabilities
-                Filter::XSSFilter($_SESSION[$key]);
-				return $_SESSION[$key];
-			}
-			else {
-				return $_SESSION[$key];
-			}
-		}
+        	// filter the value for XSS vulnerabilities
+        	return Filter::XSSFilter($_SESSION[$key]);
+        }
     }
 
     /**


### PR DESCRIPTION
This is a change to the get method to make it simpler.
Inside the Filter::XSSFilter method the input is already checked for is_string and it return the value whether or not it attempts to filter.