### PR TITLE
fix require file

### DIFF
--- a/application/core/Config.php
+++ b/application/core/Config.php
@@ -9,7 +9,7 @@ class Config
     {
         if (!self::$config) {
 
-	        $config_file = '../application/config/config.' . Environment::get() . '.php';
+	        $config_file = realpath(__DIR__) . '/../config/config.' . Environment::get() . '.php';
 
 			if (!file_exists($config_file)) {
 				return false;

--- a/application/core/Text.php
+++ b/application/core/Text.php
@@ -17,7 +17,7 @@ class Text
 		}
 	    // load config file (this is only done once per application lifecycle)
         if (!self::$texts) {
-            self::$texts = require('../application/config/texts.php');
+            self::$texts = realpath(__DIR__) . '/../config/config.' . Environment::get() . '.php';
         }
 
 	    // check if array key exists


### PR DESCRIPTION
I tested the code for AJAX request and errors occurred to include the classes file Config and Text.

When I changed the directory to the current directory worked as it should.

A small example of how this can happen is by creating an ajax request to create a password for example to include the framework files or folder composer libraries just use:

require '../../vendor/autoload.php';

on path public/requests for example.