### PR TITLE
[STICKY / IMPROVEMENT] Corrected relative paths

### DIFF
--- a/application/core/Config.php
+++ b/application/core/Config.php
@@ -9,7 +9,7 @@ class Config
     {
         if (!self::$config) {
 
-            $config_file = '../application/config/config.' . Environment::get() . '.php';
+            $config_file = dirname(__DIR__) . '/config/config.' . Environment::get() . '.php';
 
             if (!file_exists($config_file)) {
                 return false;

--- a/application/core/Text.php
+++ b/application/core/Text.php
@@ -19,7 +19,7 @@ class Text
 
         // load config file (this is only done once per application lifecycle)
         if (!self::$texts) {
-            self::$texts = require('../application/config/texts.php');
+            self::$texts = require(dirname(__DIR__) . '/config/texts.php');
         }
 
         // check if array key exists


### PR DESCRIPTION
I'm using Huge as a part of a larger setup, and in my setup, these relative path includes did not work for me — they're relative to the including file, not the included file. I fixed the file paths to be relative to the included file, and thus work no matter what the setup.
