### PR TITLE
Changed max lenght of email address

### DIFF
--- a/application/_installation/02-create-table-users.sql
+++ b/application/_installation/02-create-table-users.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS `huge`.`users` (
  `session_id` varchar(48) DEFAULT NULL COMMENT 'stores session cookie id to prevent session concurrency',
  `user_name` varchar(64) COLLATE utf8_unicode_ci NOT NULL COMMENT 'user''s name, unique',
  `user_password_hash` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'user''s password in salted and hashed format',
- `user_email` varchar(64) COLLATE utf8_unicode_ci NOT NULL COMMENT 'user''s email, unique',
+ `user_email` varchar(254) COLLATE utf8_unicode_ci NOT NULL COMMENT 'user''s email, unique',
  `user_active` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'user''s activation status',
  `user_deleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'user''s deletion status',
  `user_account_type` tinyint(1) NOT NULL DEFAULT '1' COMMENT 'user''s account type (basic, premium, etc)',


### PR DESCRIPTION
I would like to suggest changing the max lenght of the email field in the database. 

Since its provided in [this stackoverflow post](http://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address) that emails can at max be 254 chars long. 

After checking against the local php filter in the Registratonmoddel::validateUserEmail() we do not check the length of the email before its added to the database. (which could result in a failed user creation without giving back a proper error.)