### PR TITLE
PHPMailer uses UTF-8 now

### DIFF
--- a/application/core/Mail.php
+++ b/application/core/Mail.php
@@ -54,6 +54,9 @@ class Mail
     public function sendMailWithPHPMailer($user_email, $from_email, $from_name, $subject, $body)
     {
         $mail = new PHPMailer;
+        
+        // you should use UTF-8 to avoid encoding issues
+        $mail->CharSet = 'UTF-8';
 
         // if you want to send mail via PHPMailer using SMTP credentials
         if (Config::get('EMAIL_USE_SMTP')) {


### PR DESCRIPTION
PHPMailer should use UTF-8 to avoid encoding issues like 'Ã¼' instead of 'ü'.