### PR TITLE
Fixed broken Filter::XSSFilter() unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
     - cd tests
 
 # run unit tests, create result file
-script: phpunit --configuration phpunit.xml --coverage-text --coverage-clover=coverage.clover
+script: ../vendor/bin/phpunit --configuration phpunit.xml --coverage-text --coverage-clover=coverage.clover
 
 # gets tools from Scrutinizer, uploads unit tests results to Scrutinizer (?)
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=5.5.0",
         "phpmailer/phpmailer": "~5.2",
         "gregwar/captcha": "~1.1",
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "4.8.*|5.7.*"
     },
     "autoload": {
         "psr-4": { "": ["application/core/", "application/model/"] }

--- a/tests/core/FilterTest.php
+++ b/tests/core/FilterTest.php
@@ -21,10 +21,11 @@ class FilterTest extends PHPUnit_Framework_TestCase
         $integer = 123;
         $array = [1, 2, 3];
         $float = 17.001;
+        $null = null;
 
         $this->assertEquals($integer, Filter::XSSFilter($integer));
         $this->assertEquals($array, Filter::XSSFilter($array));
         $this->assertEquals($float, Filter::XSSFilter($float));
-        $this->assertNull(Filter::XSSFilter(null));
+        $this->assertNull(Filter::XSSFilter($null));
     }
 }

--- a/tests/core/FilterTest.php
+++ b/tests/core/FilterTest.php
@@ -18,9 +18,9 @@ class FilterTest extends PHPUnit_Framework_TestCase
      */
     public function testXSSFilterWithNonStringArguments()
     {
-        $this->assertEquals(123, 123);
-        $this->assertEquals(array(1, 2, 3), array(1, 2, 3));
-        $this->assertEquals(17.001, 17.001);
-        $this->assertEquals(null, null);
+        $this->assertEquals(123, Filter::XSSFilter(123));
+        $this->assertEquals(array(1, 2, 3), Filter::XSSFilter(array(1, 2, 3)));
+        $this->assertEquals(17.001, Filter::XSSFilter(17.001));
+        $this->assertEquals(null, Filter::XSSFilter(null));
     }
 }

--- a/tests/core/FilterTest.php
+++ b/tests/core/FilterTest.php
@@ -19,7 +19,7 @@ class FilterTest extends PHPUnit_Framework_TestCase
     public function testXSSFilterWithNonStringArguments()
     {
         $integer = 123;
-        $array  = [1,2,3];
+        $array = [1, 2, 3];
         $float = 17.001;
 
         $this->assertEquals($integer, Filter::XSSFilter($integer));

--- a/tests/core/FilterTest.php
+++ b/tests/core/FilterTest.php
@@ -18,9 +18,13 @@ class FilterTest extends PHPUnit_Framework_TestCase
      */
     public function testXSSFilterWithNonStringArguments()
     {
-        $this->assertEquals(123, Filter::XSSFilter(123));
-        $this->assertEquals(array(1, 2, 3), Filter::XSSFilter(array(1, 2, 3)));
-        $this->assertEquals(17.001, Filter::XSSFilter(17.001));
-        $this->assertEquals(null, Filter::XSSFilter(null));
+        $integer = 123;
+        $array  = [1,2,3];
+        $float = 17.001;
+
+        $this->assertEquals($integer, Filter::XSSFilter($integer));
+        $this->assertEquals($array, Filter::XSSFilter($array));
+        $this->assertEquals($float, Filter::XSSFilter($float));
+        $this->assertNull(Filter::XSSFilter(null));
     }
 }


### PR DESCRIPTION
Currently, `testXSSFilterWithNonStringArguments()` method in `tests\core\FilterTest.php` does not test the  `XSSFilter()` method. Changed  from:

```php
public function testXSSFilterWithNonStringArguments()
{
   $this->assertEquals(123, 123);
   $this->assertEquals(array(1, 2, 3), array(1, 2, 3));
   $this->assertEquals(17.001, 17.001);
   $this->assertEquals(null, null);
}
```
to:
```php
public function testXSSFilterWithNonStringArguments()
{
    $this->assertEquals(123, Filter::XSSFilter(123));
    $this->assertEquals(array(1, 2, 3), Filter::XSSFilter(array(1, 2, 3)));
    $this->assertEquals(17.001, Filter::XSSFilter(17.001));
    $this->assertEquals(null, Filter::XSSFilter(null));
}
```