### PR TITLE
[improvement] XSSFilter recursive implementation for array and object

### DIFF
--- a/application/core/Filter.php
+++ b/application/core/Filter.php
@@ -22,9 +22,10 @@ class Filter
      * Deeper information:
      * @see https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet
      *
-     * XSSFilter expects a value, checks if the value is a string, and if so, encodes typical script tag chars to
-     * harmless HTML (you'll see the code, it wil not be interpreted). Note that this method uses reference to the
-     * passed variable, not a copy, meaning you can use this methods like this:
+     * XSSFilter expects a value, checks if the value is a string, and if so, encodes typical script tag chars to 
+     * harmless HTML (you'll see the code, it wil not be interpreted). Then the method checks if the value is an array, 
+     * or an object and if so, makes sure all its string content is encoded (recursive call on its values).
+     * Note that this method uses reference to the assed variable, not a copy, meaning you can use this methods like this:
      *
      * CORRECT: Filter::XSSFilter($myVariable);
      * WRONG: $myVariable = Filter::XSSFilter($myVariable);
@@ -45,15 +46,33 @@ class Filter
      *
      * @see http://www.php.net/manual/en/function.htmlspecialchars.php
      *
-     * @param $value
-     * @return mixed
+     * @param  $value    The value to be filtered
+     * @return mixed    
      */
     public static function XSSFilter(&$value)
     {
+        // if argument is a string, filters that string
         if (is_string($value)) {
             $value = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
         }
 
+        // if argument is an array or an object, 
+        // recursivly filters its content 
+        } else if (is_array($value) || is_object($value)) {
+
+            /** 
+             * Make sure the element is passed by reference,
+             * In PHP 7, foreach does not use the internal array pointer. 
+             * In order to be able to directly modify array elements within the loop 
+             * precede $value with &. In that case the value will be assigned by reference. 
+             * @see http://php.net/manual/en/control-structures.foreach.php
+             */
+            foreach ($value as &$valueInValue) {
+                self::XSSFilter($valueInValue);
+            }
+        }
+
+        // other types are untouched
         return $value;
     }
 }

--- a/application/core/Filter.php
+++ b/application/core/Filter.php
@@ -54,7 +54,6 @@ class Filter
         // if argument is a string, filters that string
         if (is_string($value)) {
             $value = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
-        }
 
         // if argument is an array or an object, 
         // recursivly filters its content 

--- a/tests/core/FilterTest.php
+++ b/tests/core/FilterTest.php
@@ -3,29 +3,260 @@
 class FilterTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * When argument contains bad code the encoded (and therefore un-dangerous) string should be returned
+     * When string argument contains bad code the encoded (and therefore un-dangerous) string should be returned
      */
-    public function testXSSFilterWithBadCode()
+    public function testXSSFilterWithBadCodeInString_byref()
     {
         $codeBefore = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
-        $codeAfter = "Hello &lt;script&gt;var http = new XMLHttpRequest(); http.open(&#039;POST&#039;, &#039;example.com/my_account/delete.php&#039;, true);&lt;/script&gt;";
+        $codeAfter = 'Hello &lt;script&gt;var http = new XMLHttpRequest(); http.open(&#039;POST&#039;, &#039;example.com/my_account/delete.php&#039;, true);&lt;/script&gt;';
+
+        Filter::XSSFilter($codeBefore);
+        $this->assertEquals($codeAfter, $codeBefore);
+    }
+
+    /**
+     * When string argument contains bad code the encoded (and therefore un-dangerous) string should be returned
+     */
+    public function testXSSFilterWithBadCodeInString_return()
+    {
+        $codeBefore = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeAfter = 'Hello &lt;script&gt;var http = new XMLHttpRequest(); http.open(&#039;POST&#039;, &#039;example.com/my_account/delete.php&#039;, true);&lt;/script&gt;';
 
         $this->assertEquals($codeAfter, Filter::XSSFilter($codeBefore));
     }
 
-    /**
-     * For every type other than strings the method should return the untouched passed argument
-     */
-    public function testXSSFilterWithNonStringArguments()
+
+    public function testXSSFilterWithArrayOfBadCode_byref()
     {
-        $integer = 123;
-        $array = [1, 2, 3];
-        $float = 17.001;
+        $codeBefore1 = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeBefore2 = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeAfter = 'Hello &lt;script&gt;var http = new XMLHttpRequest(); http.open(&#039;POST&#039;, &#039;example.com/my_account/delete.php&#039;, true);&lt;/script&gt;';
+
+        $badArray = [$codeBefore1, $codeBefore2];
+        Filter::XSSFilter($badArray);         
+
+        $this->assertEquals($codeAfter, $badArray[0]);
+        $this->assertEquals($codeAfter, $badArray[1]);
+    }
+
+    public function testXSSFilterWithArrayOfBadCode_return()
+    {
+        $codeBefore1 = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeBefore2 = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeAfter = 'Hello &lt;script&gt;var http = new XMLHttpRequest(); http.open(&#039;POST&#039;, &#039;example.com/my_account/delete.php&#039;, true);&lt;/script&gt;';
+
+        $badArray = [$codeBefore1, $codeBefore2];
+
+        $this->assertEquals($codeAfter, Filter::XSSFilter($badArray)[1]);
+    }
+
+    public function testXSSFilterWithAssociativeArrayOfBadCode()
+    {
+        $codeBefore1 = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeBefore2 = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeAfter = 'Hello &lt;script&gt;var http = new XMLHttpRequest(); http.open(&#039;POST&#039;, &#039;example.com/my_account/delete.php&#039;, true);&lt;/script&gt;';
+
+        $badArray = ['foo' => $codeBefore1, 'bar' => $codeBefore2];
+        Filter::XSSFilter($badArray);         
+
+        $this->assertEquals($codeAfter, $badArray['foo']);
+        $this->assertEquals($codeAfter, $badArray['bar']);
+    }
+  
+    public function testXSSFilterWithSimpleObject_byref()
+    {
+        $codeBefore = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeAfter = 'Hello &lt;script&gt;var http = new XMLHttpRequest(); http.open(&#039;POST&#039;, &#039;example.com/my_account/delete.php&#039;, true);&lt;/script&gt;';
+        $integerBefore = 123;
+        $integerAfter  = 123;
+
+        $object = new stdClass();
+        $object->int = $integerBefore;
+        $object->str = 'foo';
+        $object->badstr = $codeBefore;
+
+        Filter::XSSFilter($object);         
+
+        $this->assertEquals('foo', $object->str);
+        $this->assertEquals($integerAfter, $object->int);
+        $this->assertEquals($codeAfter, $object->badstr);
+    }
+
+    public function testXSSFilterWithSimpleObject_return()
+    {
+        $codeBefore = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeAfter = 'Hello &lt;script&gt;var http = new XMLHttpRequest(); http.open(&#039;POST&#039;, &#039;example.com/my_account/delete.php&#039;, true);&lt;/script&gt;';
+        $integerBefore = 123;
+        $integerAfter  = 123;
+
+        $object = new stdClass();
+        $object->str = 'foo';
+        $object->badstr = $codeBefore;
+
+        $this->assertEquals($codeAfter, Filter::XSSFilter($object)->badstr);
+    }
+
+    public function testXSSFilterWithObjectContainingArray_byref()
+    {
+        $codeBefore1 = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeBefore2 = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeAfter = 'Hello &lt;script&gt;var http = new XMLHttpRequest(); http.open(&#039;POST&#039;, &#039;example.com/my_account/delete.php&#039;, true);&lt;/script&gt;';
+
+        $badArray = ['foo' => 'bar', 'bad1' => $codeBefore1, 'bad2' => $codeBefore2];
+        $object = new stdClass();
+        $object->badArray = $badArray;
+
+        Filter::XSSFilter($object);         
+
+        $this->assertEquals('bar', $object->badArray['foo']);
+        $this->assertEquals($codeAfter, $object->badArray['bad1']);
+        $this->assertEquals($codeAfter, $object->badArray['bad2']);
+    }
+
+    public function testXSSFilterWithObjectContainingArray_return()
+    {
+        $codeBefore = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeAfter = 'Hello &lt;script&gt;var http = new XMLHttpRequest(); http.open(&#039;POST&#039;, &#039;example.com/my_account/delete.php&#039;, true);&lt;/script&gt;';
+
+        $badArray = ['foo' => 'bar', 'bad' => $codeBefore];
+        $object = new stdClass();
+        $object->badArray = $badArray;
+
+        $this->assertEquals($codeAfter,  Filter::XSSFilter($object)->badArray['bad']);
+    }
+
+    public function testXSSFilterWithObjectContainingObject_byref()
+    {
+        $codeBefore1 = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeBefore2 = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeAfter = 'Hello &lt;script&gt;var http = new XMLHttpRequest(); http.open(&#039;POST&#039;, &#039;example.com/my_account/delete.php&#039;, true);&lt;/script&gt;';
+
+
+        $object = new stdClass();
+        $object->badStr = $codeBefore1;
+
+        $childObject = new stdClass();
+        $childObject->badStr = $codeBefore2;
+
+        $object->badObject = $childObject;
+
+        Filter::XSSFilter($object);         
+
+        $this->assertEquals($codeAfter, $object->badStr);
+        $this->assertEquals($codeAfter, $object->badObject->badStr);
+    }
+
+    public function testXSSFilterWithObjectContainingObject_return()
+    {
+        $codeBefore = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeAfter = 'Hello &lt;script&gt;var http = new XMLHttpRequest(); http.open(&#039;POST&#039;, &#039;example.com/my_account/delete.php&#039;, true);&lt;/script&gt;';
+
+        $object = new stdClass();
+        $childObject = new stdClass();
+        $childObject->badStr = $codeBefore;
+        $object->badObject = $childObject;
+
+        $this->assertEquals($codeAfter, Filter::XSSFilter($object)->badObject->badStr);
+    }
+
+
+    /**
+     * For every type other than strings or arrays, the method should return the untouched passed argument
+     */
+    public function testXSSFilterWithNonStringOrArrayArguments()
+    {
+        $integerBefore = 123;
+        $integerAfter  = 123;
+        $arrayBefore   = [1, 2, 3];
+        $arrayAfter    = [1, 2, 3];
+        $floatsBefore  = 17.001;
+        $floatsAfter   = 17.001;
         $null = null;
 
-        $this->assertEquals($integer, Filter::XSSFilter($integer));
-        $this->assertEquals($array, Filter::XSSFilter($array));
-        $this->assertEquals($float, Filter::XSSFilter($float));
+        Filter::XSSFilter($integerBefore);         
+        Filter::XSSFilter($arrayBefore);         
+        Filter::XSSFilter($floatsBefore);         
+        Filter::XSSFilter($null);         
+
+        $this->assertEquals($integerAfter, $integerBefore);
+        $this->assertEquals($arrayBefore, $arrayAfter);
+        $this->assertEquals($floatsBefore, $floatsAfter);
+        $this->assertNull($null);
+    }   
+
+     /**
+     * For every type other than strings or arrays, the method should return the untouched passed argument
+     */
+    public function testXSSFilterWithNonStringOrArrayArguments_return()
+    {
+        $integerBefore = 123;
+        $integerAfter  = 123;
+        $arrayBefore   = [1, 2, 3];
+        $arrayAfter    = [1, 2, 3];
+        $floatsBefore  = 17.001;
+        $floatsAfter   = 17.001;
+        $null = null;
+
+        $this->assertEquals($integerAfter,  Filter::XSSFilter($integerBefore));
+        $this->assertEquals($arrayBefore,  Filter::XSSFilter($arrayBefore));
+        $this->assertEquals($floatsBefore, Filter::XSSFilter($floatsBefore));
         $this->assertNull(Filter::XSSFilter($null));
+    }   
+
+     /**
+     * For every type other than strings or arrays, the method should return the untouched passed argument
+     */
+    public function testXSSFilterWithNonStringOrArrayArguments_byref()
+    {
+        $integerBefore = 123;
+        $integerAfter  = 123;
+        $arrayBefore   = [1, 2, 3];
+        $arrayAfter    = [1, 2, 3];
+        $floatsBefore  = 17.001;
+        $floatsAfter   = 17.001;
+        $null = null;
+
+        Filter::XSSFilter($integerBefore);         
+        Filter::XSSFilter($arrayBefore);         
+        Filter::XSSFilter($floatsBefore);         
+        Filter::XSSFilter($null);         
+
+        $this->assertEquals($integerAfter, $integerBefore);
+        $this->assertEquals($arrayBefore, $arrayAfter);
+        $this->assertEquals($floatsBefore, $floatsAfter);
+        $this->assertNull($null);
+    }   
+
+    public function testXSSFilterWithComplexArrayOfBadCode()
+    {
+        $codeBefore1 = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeBefore2 = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeBefore3 = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeBefore4 = "Hello <script>var http = new XMLHttpRequest(); http.open('POST', 'example.com/my_account/delete.php', true);</script>";
+        $codeAfter = 'Hello &lt;script&gt;var http = new XMLHttpRequest(); http.open(&#039;POST&#039;, &#039;example.com/my_account/delete.php&#039;, true);&lt;/script&gt;';
+        
+        $badObject = new stdClass();
+        $badObject->badstr = $codeBefore4;
+
+        $badArray = [ 
+            'foo', 
+            $codeBefore1, 
+            'bar', 
+            [
+                'foo' => $codeBefore2, 
+                'bar' => $codeBefore3
+            ],
+            $badObject
+        ];
+
+        Filter::XSSFilter($badArray);         
+
+        $this->assertEquals('foo', $badArray[0]);
+        $this->assertEquals($codeAfter, $badArray[1]);
+        $this->assertEquals('bar', $badArray[2]);
+        $this->assertEquals($codeAfter, $badArray[3]['foo']);
+        $this->assertEquals($codeAfter, $badArray[3]['bar']);
+        $this->assertEquals($codeAfter, $badArray[4]->badstr);
     }
+
 }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -14,11 +14,4 @@
             <directory>./core/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">../application/core</directory>
-            <directory suffix=".php">../application/model</directory>
-            <directory suffix=".php">../application/controller</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -14,4 +14,11 @@
             <directory>./core/</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">../application/core</directory>
+            <directory suffix=".php">../application/model</directory>
+            <directory suffix=".php">../application/controller</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
This should help to close open issue https://github.com/panique/huge/issues/790 and  the blocked PR https://github.com/panique/huge/pull/794 about `XSSFilter` :)

This PR contains something similar as the solution proposed here https://github.com/panique/huge/issues/790 : the `Filter::XssFilter()` method takes now both `string`, `array` and `object` as parameter (recursive to array values or object preperties).