### PR TITLE
Solved permissions problems with Avatars folder using secure 755.

### DIFF
--- a/_one-click-installation/bootstrap.sh
+++ b/_one-click-installation/bootstrap.sh
@@ -77,6 +77,10 @@ sudo mysql -h "localhost" -u "root" "-p${PASSWORD}" < "/var/www/html/${PROJECTFO
 
 # writing rights to avatar folder
 sudo chown -R www-data "/var/www/html/${PROJECTFOLDER}/public/avatars"
+
+# If you are working with Vagrant, adding the www-data user to vagrant's group let you upload images to the avatars folder with 775 permissions.  Of course, it also applies to other folders.
+#sudo usermod -a -G vagrant www-data
+
 # if this didn't work for you, you can also try the hard way:
 #sudo chmod 0777 -R "/var/www/html/${PROJECTFOLDER}/public/avatars"
 


### PR DESCRIPTION
[VAGRANT]
I'was creating a system for uploading users' files to the server. For this purpose I coded a script that creates a personal folder with `755` permissions. This was working, but when I was trying to move a file via `move_uploaded_file()` to the folder I wasn't able to write anything. 

So I decided to check the php user, and it was running by vagrant user. Also I checked the owner of the files and it was vagrant too. At the end, I decided to try adding the www-data user to vagrant's group. This let me upload files to the folders with `755` permissions.  Of course, it also applies to other folders, including Avatars folder. In reference with issue #143.

`sudo usermod -a -G vagrant www-data`
