### PR TITLE
Upgrade PHPMailer to v6.0

### DIFF
--- a/application/core/Mail.php
+++ b/application/core/Mail.php
@@ -1,5 +1,8 @@
 <?php
 
+/* Using PHPMailer's namespace */
+use PHPMailer\PHPMailer\PHPMailer;
+
 /**
  * Class Mail
  *

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require-dev": {
         "php": ">=5.5.0",
-        "phpmailer/phpmailer": "~5.2",
+        "phpmailer/phpmailer": "~6.0",
         "gregwar/captcha": "~1.1",
         "phpunit/phpunit": "4.8.*|5.7.*"
     },


### PR DESCRIPTION
PHPMailer 5.2 won't get any security updates anymore (since December):

https://github.com/PHPMailer/PHPMailer#user-content-legacy-versions

I have upgraded PHPMailer to version 6, that does also support PHP 5.5 (like HUGE).