### PR TITLE
Session validation improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
     - cd tests
 
 # run unit tests, create result file
-script: ../vendor/bin/phpunit --verbose  --configuration phpunit.xml --coverage-text --coverage-clover=coverage.clover
+script: ../vendor/bin/phpunit --verbose --debug  --configuration phpunit.xml --coverage-text --coverage-clover=coverage.clover
 
 # gets tools from Scrutinizer, uploads unit tests results to Scrutinizer (?)
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
     - cd tests
 
 # run unit tests, create result file
-script: ../vendor/bin/phpunit --configuration phpunit.xml --coverage-text --coverage-clover=coverage.clover
+script: ../vendor/bin/phpunit --verbose  --configuration phpunit.xml --coverage-text --coverage-clover=coverage.clover
 
 # gets tools from Scrutinizer, uploads unit tests results to Scrutinizer (?)
 after_script:

--- a/application/core/Auth.php
+++ b/application/core/Auth.php
@@ -72,7 +72,7 @@ class Auth
      */
     public static function checkSessionConcurrency(){
         if(Session::userIsLoggedIn()){
-            if(Session::isConcurrentSessionExists()){
+            if(Session::isSessionBroken()){
                 LoginModel::logout();
                 Redirect::home();
                 exit();

--- a/application/core/Session.php
+++ b/application/core/Session.php
@@ -84,8 +84,10 @@ class Session
     }
 
     /**
-     * checks for session concurrency
-     *
+     * checks for broken session 
+     * Session could be broken by Session concurrency or when user is deleted / suspended
+     * 
+     * - Session concurrency is done as the following:
      * This is done as the following:
      * UserA logs in with his session id('123') and it will be stored in the database.
      * Then, UserB logs in also using the same email and password of UserA from another PC,
@@ -94,6 +96,9 @@ class Session
      * Now, Whenever UserA performs any action,
      * You then check the session_id() against the last one stored in the database('456'),
      * If they don't match then log both of them out.
+     * 
+     * - Check for deleted / suspended users:
+     * Suspended/deleted users have no userSessionId anymore stored in database
      *
      * @access public
      * @static static method
@@ -101,7 +106,7 @@ class Session
      * @see Session::updateSessionId()
      * @see http://stackoverflow.com/questions/6126285/php-stop-concurrent-user-logins
      */
-    public static function isConcurrentSessionExists()
+    public static function isSessionBroken()
     {
         $session_id = session_id();
         $userId     = Session::get('user_id');
@@ -117,7 +122,7 @@ class Session
             $result = $query->fetch();
             $userSessionId = !empty($result)? $result->session_id: null;
 
-            return $session_id !== $userSessionId;
+            return empty($userSessionId) || $session_id !== $userSessionId;
         }
 
         return false;

--- a/tests/core/ConfigTest.php
+++ b/tests/core/ConfigTest.php
@@ -26,6 +26,9 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      */
 	public function testGetDefaultEnvironment()
 	{
+		// for testing
+		header_remove(); 
+
         // manually set environment to "development"
 		putenv('APPLICATION_ENV=development');
 

--- a/tests/core/ConfigTest.php
+++ b/tests/core/ConfigTest.php
@@ -23,6 +23,8 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 
     /**
      * Checks if the correct config file for an EXISTING environment / config is called.
+	 * 
+     * @runInSeparateProcess
      */
 	public function testGetDefaultEnvironment()
 	{
@@ -36,8 +38,14 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals('index', Config::get('DEFAULT_ACTION'));
 	}
 
+    /**
+     * @runInSeparateProcess
+     */
 	public function testGetFailingEnvironment()
 	{
+		// for testing
+		header_remove(); 
+
         // manually set environment to "foobar" (and non-existing environment)
 		putenv('APPLICATION_ENV=foobar');
 

--- a/tests/core/EnvironmentTest.php
+++ b/tests/core/EnvironmentTest.php
@@ -8,13 +8,8 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals('testing', Environment::get());
 
 		putenv('APPLICATION_ENV=');
-		$this->assertEquals('development', Environment::get());
-	}
 
-	public function testGetDevelopment()
-	{
-		putenv('APPLICATION_ENV=development');
-		// call for environment should return "development"
+		// call for environment should now return "development", the default value
 		$this->assertEquals('development', Environment::get());
 	}
 
@@ -24,5 +19,11 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals('production', Environment::get());
 	}
 
+	public function testGetDevelopment()
+	{
+		putenv('APPLICATION_ENV=development');
+		// call for environment should return "development"
+		$this->assertEquals('development', Environment::get());
+	}
 	
 }

--- a/tests/core/EnvironmentTest.php
+++ b/tests/core/EnvironmentTest.php
@@ -4,7 +4,10 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
 {
 	public function testGetDefault()
 	{
-		// call for environment should return "development"
+		// call for environment should return "testing" like set in .travis.yml
+		$this->assertEquals('testing', Environment::get());
+
+		putenv('APPLICATION_ENV=');
 		$this->assertEquals('development', Environment::get());
 	}
 
@@ -20,4 +23,6 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
 		putenv('APPLICATION_ENV=production');
 		$this->assertEquals('production', Environment::get());
 	}
+
+	
 }


### PR DESCRIPTION
This is the change proposed here #885
By the way, fixed Config and Environment tests on travis with recent PHP versions and made phpunit verbose 
 
> When a user is suspended using `AdminModel::setAccountSuspensionAndDeletionStatus()` that internally calls `AdminModel::resetUserSession()` method, the feedback message says "_The selected user has been successfully kicked out of the system (by resetting this user's session)",_
> 
> That's not really true. In facts, the suspended user is still able to access protected pages until its session expires or he logouts. (Then, he is not able to login anymore as expected)
> 
> There is no way to kick out the user instantanitly (_strictly speaking_). On the other hand, it's possible, **with a minor change**, to not wait its session expires.
> 
> The `Session::isConcurrentSessionExists()` method that checks for session concurrency could be changed to **`Session::isSessionBroken()`** and check two things (with only one database call) :
> 
>  - session concurrency exists
> 
>  - or **sessionId does not exist anymore in database**
> 
> 
> This way, the suspended user is kicked out **as soon he tries to access another page**.
> 
> Actual method in `Session` class:
> 
> ```
> public static function isConcurrentSessionExists()
> {
>         $session_id = session_id();
>         $userId     = Session::get('user_id');
> 
>         if (isset($userId) && isset($session_id)) {
> 
>             $database = DatabaseFactory::getFactory()->getConnection();
>             $sql = "SELECT session_id FROM users WHERE user_id = :user_id LIMIT 1";
> 
>             $query = $database->prepare($sql);
>             $query->execute(array(":user_id" => $userId));
> 
>             $result = $query->fetch();
>             $userSessionId = !empty($result)? $result->session_id: null;
> 
>             return $session_id !== $userSessionId;
>         }
>         return false;
> }
> ```
> 
> Proposed:
> 
> ```
> public static function isSessionBroken()
> // change function name ^^^^^^^^^^^^^^^^ just to be coherent
> {
>         $session_id = session_id();
>         $userId     = Session::get('user_id');
> 
>         if (isset($userId) && isset($session_id)) {
> 
>             $database = DatabaseFactory::getFactory()->getConnection();
>             $sql = "SELECT session_id FROM users WHERE user_id = :user_id LIMIT 1";
> 
>             $query = $database->prepare($sql);
>             $query->execute(array(":user_id" => $userId));
> 
>             $result = $query->fetch();
>             $userSessionId = !empty($result)? $result->session_id: null;
> 
>             return empty($userSessionId) || $session_id !== $userSessionId;
> // and add this  ^^^^^^^^^^^^^^^^^^^^^^^^^^
>         }
>         return false;
> }
> ```
> 
> and don't forget to change function in `Auth` class
> 
> ```
> public static function checkSessionConcurrency()
> {
>         if(Session::userIsLoggedIn()){
>       //    if(Session::isConcurrentSessionExists()){
>             if(Session::isSessionBroken()){
>                 LoginModel::logout();
>                 Redirect::home();
>                 exit();
>             }
>         }
> }
> ```
